### PR TITLE
avoid nested ifs to reduce cognitive complexity

### DIFF
--- a/src/LedRGB.cpp
+++ b/src/LedRGB.cpp
@@ -22,7 +22,7 @@ void LedRGB::Update()
 
 void LedRGB::HandleCommand(Command cmd)
 {
-    //if (cmd.cmd == ("RGB"))
+    //if (cmd.cmd == "RGB")
     //{
         // RGB:0;0;0
     //    print("RGB : ", cmd.data[0]);

--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -87,31 +87,37 @@ void Motor::Update(float linear_speed_mms, float linear_direction_rad, float ang
 
 void Motor::HandleCommand(Command cmd)
 {
-
-    if (cmd.cmd.startsWith("Motor"))
-    {
-        if (cmd.cmd == ("Motor") && cmd.size == 3)
-        {
-            // Motor:1;1000;50
-            // Motor:1;1;50
-            if (cmd.data[2] >= 0 && cmd.data[2] <= 100)
-            {
-                print("Motor ", cmd.data[0]);
-                print(" with freq ", cmd.data[1], " Hz");
-                println(" with duty ", cmd.data[2], " %");
-                if (cmd.data[0] == 1)
-                    stepper1->setPWM(cmd.data[1], cmd.data[2]);
-                if (cmd.data[0] == 2)
-                    stepper2->setPWM(cmd.data[1], cmd.data[2]);
-                if (cmd.data[0] == 3 && motorBaseType == OMNIDIRECTIONAL_3_MOTORS)
-                    stepper3->setPWM(cmd.data[1], cmd.data[2]);
-            }
-        }
-        else
-        {
-            println("Not a Motor Command ");
-        }
+    // maybe this should be handled in a generic commands handler and dispatcher
+    if (!cmd.cmd.startsWith("Motor")){
+        println("Not a Motor Command ");
+        return;
     }
+    
+    // why do we check "Motor" twice?
+    if (cmd.cmd != "Motor" || cmd.size != 3)
+    {
+        println("Invalid Motor Command");
+        return;
+    }
+
+    // Motor:1;1000;50
+    // Motor:1;1;50
+    if (cmd.data[2] < 0 || 100 < cmd.data[2])
+    {
+        println("Invalid Duty Cycle");
+        return;
+    }
+
+    print("Motor ", cmd.data[0]);
+    print(" with freq ", cmd.data[1], " Hz");
+    println(" with duty ", cmd.data[2], " %");
+    
+    if (cmd.data[0] == 1)
+        stepper1->setPWM(cmd.data[1], cmd.data[2]);
+    if (cmd.data[0] == 2)
+        stepper2->setPWM(cmd.data[1], cmd.data[2]);
+    if (cmd.data[0] == 3 && motorBaseType == OMNIDIRECTIONAL_3_MOTORS)
+        stepper3->setPWM(cmd.data[1], cmd.data[2]);
 }
 
 void Motor::PrintCommandHelp()

--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -87,37 +87,27 @@ void Motor::Update(float linear_speed_mms, float linear_direction_rad, float ang
 
 void Motor::HandleCommand(Command cmd)
 {
-    // maybe this should be handled in a generic commands handler and dispatcher
-    if (!cmd.cmd.startsWith("Motor")){
-        println("Not a Motor Command ");
-        return;
-    }
-    
-    // why do we check "Motor" twice?
-    if (cmd.cmd != "Motor" || cmd.size != 3)
+    if (cmd.cmd == "Motor" && cmd.size == 3)
     {
-        println("Invalid Motor Command");
-        return;
-    }
+        // Motor:1;1000;50
+        // Motor:1;1;50
+        if (cmd.data[2] < 0 || 100 < cmd.data[2])
+        {
+            println("Invalid Duty Cycle");
+            return;
+        }
 
-    // Motor:1;1000;50
-    // Motor:1;1;50
-    if (cmd.data[2] < 0 || 100 < cmd.data[2])
-    {
-        println("Invalid Duty Cycle");
-        return;
+        print("Motor ", cmd.data[0]);
+        print(" with freq ", cmd.data[1], " Hz");
+        println(" with duty ", cmd.data[2], " %");
+        
+        if (cmd.data[0] == 1)
+            stepper1->setPWM(cmd.data[1], cmd.data[2]);
+        if (cmd.data[0] == 2)
+            stepper2->setPWM(cmd.data[1], cmd.data[2]);
+        if (cmd.data[0] == 3 && motorBaseType == OMNIDIRECTIONAL_3_MOTORS)
+            stepper3->setPWM(cmd.data[1], cmd.data[2]);
     }
-
-    print("Motor ", cmd.data[0]);
-    print(" with freq ", cmd.data[1], " Hz");
-    println(" with duty ", cmd.data[2], " %");
-    
-    if (cmd.data[0] == 1)
-        stepper1->setPWM(cmd.data[1], cmd.data[2]);
-    if (cmd.data[0] == 2)
-        stepper2->setPWM(cmd.data[1], cmd.data[2]);
-    if (cmd.data[0] == 3 && motorBaseType == OMNIDIRECTIONAL_3_MOTORS)
-        stepper3->setPWM(cmd.data[1], cmd.data[2]);
 }
 
 void Motor::PrintCommandHelp()

--- a/src/OTOS.cpp
+++ b/src/OTOS.cpp
@@ -153,7 +153,7 @@ void OpticalTrackingOdometrySensor::Update()
 
 void OpticalTrackingOdometrySensor::HandleCommand(Command cmd)
 {
-    //if (cmd.cmd == ("Otos"))
+    //if (cmd.cmd == "Otos")
     //{
         // Otos:0;0
     //    print("Otos : ", cmd.data[0]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,7 +208,7 @@ void loop()
       otos.PrintCommandHelp();
       motor.PrintCommandHelp();
     }
-    else if (cmd.cmd == ("GoToPose") && cmd.size == 3)
+    else if (cmd.cmd == "GoToPose" && cmd.size == 3)
     {
       // GoToPose:500;500;0
       // GoToPose:50;50;0
@@ -223,7 +223,7 @@ void loop()
       print(" h=", goTo.h);
       println();
     }
-    else if (cmd.cmd == ("SetPose") && cmd.size == 3)
+    else if (cmd.cmd == "SetPose" && cmd.size == 3)
     {
       // SetPose:500;500;0
       DisableTimerMotion();
@@ -238,7 +238,7 @@ void loop()
       println();
       EnableTimerMotion();
     }
-    else if(cmd.cmd == ("PF") && cmd.size == 1)
+    else if(cmd.cmd == "PF" && cmd.size == 1)
     {
       // PathFinding
       // PF:5
@@ -251,20 +251,20 @@ void loop()
       {
         print("PF Not Found");
       }
-    }
-    else if(cmd.cmd == ("VertexList") && cmd.size == 0)
+    }    
+    else if(cmd.cmd == "VertexList")
     {
       Mapping::PrintVertexList();
     }
-    else if(cmd.cmd == ("SegmentList") && cmd.size == 0)
+    else if(cmd.cmd == "SegmentList")
     {
       Mapping::PrintSegmentList();
     }
-    else if(cmd.cmd == ("CircleList") && cmd.size == 0)
+    else if(cmd.cmd == "CircleList")
     {
       Mapping::PrintCircleList();
     }
-    else if(cmd.cmd == ("MappingList") && cmd.size == 0)
+    else if(cmd.cmd == "MappingList")
     {
       Mapping::PrintVertexList();
       Mapping::PrintSegmentList();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,15 +200,15 @@ void loop()
   {
     Command cmd = ESP32_Helper::GetCommand();
 
-    if (cmd.cmd.startsWith("Help"))
+    otos.HandleCommand(cmd);
+    motor.HandleCommand(cmd);
+
+    if (cmd.cmd == "Help")
     {
       otos.PrintCommandHelp();
       motor.PrintCommandHelp();
     }
-    otos.HandleCommand(cmd);
-    motor.HandleCommand(cmd);
-
-    if (cmd.cmd == ("GoToPose") && cmd.size == 3)
+    else if (cmd.cmd == ("GoToPose") && cmd.size == 3)
     {
       // GoToPose:500;500;0
       // GoToPose:50;50;0
@@ -223,7 +223,7 @@ void loop()
       print(" h=", goTo.h);
       println();
     }
-    if (cmd.cmd == ("SetPose") && cmd.size == 3)
+    else if (cmd.cmd == ("SetPose") && cmd.size == 3)
     {
       // SetPose:500;500;0
       DisableTimerMotion();
@@ -238,7 +238,7 @@ void loop()
       println();
       EnableTimerMotion();
     }
-    if(cmd.cmd == ("PF") && cmd.size == 1)
+    else if(cmd.cmd == ("PF") && cmd.size == 1)
     {
       // PathFinding
       // PF:5
@@ -252,20 +252,19 @@ void loop()
         print("PF Not Found");
       }
     }
-    
-    if(cmd.cmd == ("VertexList") && cmd.size == 0)
+    else if(cmd.cmd == ("VertexList") && cmd.size == 0)
     {
       Mapping::PrintVertexList();
     }
-    if(cmd.cmd == ("SegmentList") && cmd.size == 0)
+    else if(cmd.cmd == ("SegmentList") && cmd.size == 0)
     {
       Mapping::PrintSegmentList();
     }
-    if(cmd.cmd == ("CircleList") && cmd.size == 0)
+    else if(cmd.cmd == ("CircleList") && cmd.size == 0)
     {
       Mapping::PrintCircleList();
     }
-    if(cmd.cmd == ("MappingList") && cmd.size == 0)
+    else if(cmd.cmd == ("MappingList") && cmd.size == 0)
     {
       Mapping::PrintVertexList();
       Mapping::PrintSegmentList();


### PR DESCRIPTION
le principe ce que les ifs gèrent les edges case et non pas le déroulement classique.

Le comportement de base de ta fonction doit se trouver au premier niveau. Ensuite tu gères les exceptions et les erreurs avec des ifs ou autre.
Cela permet une meilleure lecture de la fonction, ça réduit ce qu'on appelle la complexité cognitive. ça rend le code plus simple à lire pour les développeurs.

Dans l'absolu on évite plus de 3 niveau d'imbrications de if/while/for

closes [AZURSD9JeGf3pN8qsa09](https://sonarcloud.io/project/issues?impactSeverities=HIGH&issueStatuses=OPEN%2CCONFIRMED&id=Mecapitronic_Omni_Firmware&open=AZURSD9JeGf3pN8qsa08)